### PR TITLE
Visitors must register or log in before checkout

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -13,10 +13,6 @@ class CartController < ApplicationController
   end
 
   def show
-    @user = 
-    if !current_user
-      flash[:notice] = "You must register or log in to checkout"
-    end
   end
 
   def empty

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -13,6 +13,10 @@ class CartController < ApplicationController
   end
 
   def show
+    @user = 
+    if !current_user
+      flash[:notice] = "You must register or log in to checkout"
+    end
   end
 
   def empty

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -16,6 +16,8 @@
       <%= button_to 'Remove', "/cart/#{item.id}", method: :delete %>
     </section>
   <% end %>
-  <%= button_to 'Check Out', new_order_path, method: :get %>
+<% if @current_user %>
+    <%= button_to 'Check Out', new_order_path, method: :get %>
+<% end %>
   <%= button_to 'Empty Cart', '/cart', method: :delete %>
 <% end %>

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -18,6 +18,8 @@
   <% end %>
 <% if @current_user %>
     <%= button_to 'Check Out', new_order_path, method: :get %>
+<% else %>
+    <p> You must <%= link_to 'register', register_path %> or <%= link_to 'log in', '/login' %> to finish checkout out. </p>
 <% end %>
   <%= button_to 'Empty Cart', '/cart', method: :delete %>
 <% end %>

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -175,7 +175,8 @@ RSpec.describe 'Cart Show Page' do
 
           visit '/cart'
 
-          expect(page).to have_content("You must register or log in to checkout")
+          expect(page).to have_link('register')
+          expect(page).to have_link('log in')
           expect(page).to have_no_button("Checkout")
         end
       end

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -167,6 +167,18 @@ RSpec.describe 'Cart Show Page' do
         expect(page).to_not have_content("#{@hippo.name}")
         expect(page).to have_content("Cart: 0")
       end
+
+      describe 'when I add items to the cart and visit the cart page' do
+        it 'I see a message to me to register or log in to finish checkout' do
+          visit item_path(@hippo)
+          click_button 'Add to Cart'
+
+          visit '/cart'
+
+          expect(page).to have_content("You must register or log in to checkout")
+          expect(page).to have_no_button("Checkout")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[x] Add cart show spec test to verify a visitor cannot checkout before logging in or registering
[x] Refactor cart show page to have links connecting visitor to register and log in pages if they are not a registered user or not logged in


